### PR TITLE
refactor: replace slackclient with slack_sdk

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-slackclient = "==1.3.1"
+slack_sdk = "*"
 aws-cli = "*"
 
 [requires]

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,1 +1,1 @@
-slackclient==1.3.1
+slack_sdk==3.15.2

--- a/src/slack_helper.py
+++ b/src/slack_helper.py
@@ -107,6 +107,5 @@ def send_msg(ch, attachments):
 def update_msg(ch, ts, attachments):
     r = client.chat_update(channel=ch, 
                            ts=ts, 
-                           attachments=attachments
-                           )    
+                           attachments=attachments)    
     return r

--- a/template.yml
+++ b/template.yml
@@ -3,10 +3,6 @@ Transform: AWS::Serverless-2016-10-31
 Description: Code Pipeline Slack Notifier
 
 Parameters:
-  SlackOAuthAccessToken:
-    MinLength: 1
-    Type: String
-    NoEcho: True
   SlackBotUserOAuthAccessToken:
     MinLength: 1
     Type: String
@@ -36,7 +32,6 @@ Resources:
       ReservedConcurrentExecutions: 1
       Environment:
         Variables:
-          SLACK_TOKEN: !Ref SlackOAuthAccessToken
           SLACK_BOT_TOKEN: !Ref SlackBotUserOAuthAccessToken
           SLACK_BOT_NAME: !Ref SlackBotName
           SLACK_BOT_ICON: !Ref SlackBotIcon


### PR DESCRIPTION
<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/babel/babel/blob/master/CONTRIBUTING.md

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/) followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            |  <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Major: Breaking Change?  |
| Minor: New Feature?      |
| Tests Added + Pass?      | No
| Documentation PR         | <!-- If so, add `[skip ci]` to your commit message to skip CI -->
| Any Dependency Changes?  | replaced `slackclient` with `slack_sdk`
| License                  | MIT

<!-- Describe your changes below in as much detail as possible -->
Slack changed their SDK and we can no longer generate `SLACK_TOKEN` / `SLACK_BOT_TOKEN` pairs.

I updated slack client to latest SDK.

I noticed there are some layout issues and the phases under stages are getting messed up.
I suspect something changed in the slack attachments SDK.

This is how it looks now:
![image](https://user-images.githubusercontent.com/9220101/160108489-a26ddd75-8ce8-43ac-aec4-2725c813b94d.png)
